### PR TITLE
Bump einops to 0.5.0 to fix import errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-einops==0.4.0
+einops==0.5.0
 matplotlib==3.7.0
 numpy==1.23.5
 pandas==1.5.3


### PR DESCRIPTION
As already referenced in https://github.com/thuml/Time-Series-Library/issues/405, einsum is not implemented the einops library until version 0.5.0. Using the 0.4.0 version of the library causes import errors when the example scripts are run.